### PR TITLE
ci: add verbose test output and fix Docker registry case sensitivity resolves GHCR push error:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Push to registry (main branch only)
         if: github.ref == 'refs/heads/main'
         run: |
-          docker tag argus-events:latest ghcr.io/${{ github.repository }}:latest
-          docker push ghcr.io/${{ github.repository }}:latest
+          docker tag argus-events:latest ghcr.io/${{ github.repository_owner }}/argus-events:latest
+          docker push ghcr.io/${{ github.repository_owner }}/argus-events:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build and test
-        run: scripts/build.sh --color
+        run: scripts/build.sh --color --verbose
 
       - name: Login to GitHub Container Registry
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
ci: add verbose test output and fix Docker registry case sensitivity
    
- Add --verbose flag to build script for detailed test output in CI logs
- Fix Docker registry push by using github.repository_owner for lowercase names
- Resolves GHCR push error: repository names must be lowercase
